### PR TITLE
chore(package): upgrade jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/sarunas/fizz-buzz-kata#readme",
   "devDependencies": {
-    "jest": "^22.4.2"
+    "jest": "^23.5.0"
   }
 }


### PR DESCRIPTION
jest ^22 has issue, when running it breaks with:
```
 SecurityError: localStorage is not available for opaque origins

             at Window.get localStorage [as localStorage]
             (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
                       at Array.forEach (<anonymous>)
```

jest ^23 no longer has this issue

more https://github.com/jsdom/jsdom/issues/2304